### PR TITLE
fix workclocktimeref filter intersection

### DIFF
--- a/api/src/services/category.js
+++ b/api/src/services/category.js
@@ -36,11 +36,16 @@ const getCategories = async ({
   try {
     const CategoryModel = await categoryModel.getModel(chainId);
     const request = {
-      ...(minWorkClockTimeRef !== undefined && {
-        workClockTimeRef: { $gte: minWorkClockTimeRef },
-      }),
-      ...(maxWorkClockTimeRef !== undefined && {
-        workClockTimeRef: { $lte: maxWorkClockTimeRef },
+      ...((minWorkClockTimeRef !== undefined ||
+        maxWorkClockTimeRef !== undefined) && {
+        workClockTimeRef: {
+          ...(minWorkClockTimeRef !== undefined && {
+            $gte: minWorkClockTimeRef,
+          }),
+          ...(maxWorkClockTimeRef !== undefined && {
+            $lte: maxWorkClockTimeRef,
+          }),
+        },
       }),
     };
     const sort = {


### PR DESCRIPTION
This PR fixes this :bug: 
`minWorkClockTimeRef` used to be ignored when `maxWorkClockTimeRef` was passed