### PR TITLE
fix broken yaml syntax in openapi.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next
+
+- fix openapi for `GET /requestorders`
+
 ## v6.4.0
 
 - add new filters to retrieve orders on strict or non-strict assets authorization, excluding or including orders with "any" asset authorized for GET `/apporders`, `/datasetorders`, `/workerpoolorders`, `/requestorders`

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -762,15 +762,15 @@ paths:
             type: string
             example: 'any'
         - name: workerpool
-            in: query
-            description: workerpoolrestrict address to include in results
-            schema:
-              type: string
+          in: query
+          description: workerpoolrestrict address to include in results
+          schema:
+            type: string
         - name: isWorkerpoolStrict
-            in: query
-            description: exclude orders with permissions allowing "any" workerpool (default false, ignored if `workerpool` is not specified)
-            schema:
-              type: boolean
+          in: query
+          description: exclude orders with permissions allowing "any" workerpool (default false, ignored if `workerpool` is not specified)
+          schema:
+            type: boolean
         - name: beneficiary
           in: query
           description: beneficiary address to filter results on (accepts address or "any")


### PR DESCRIPTION
before:

![image](https://github.com/iExecBlockchainComputing/iexec-market-api/assets/26487010/5f58f815-36cd-4662-b6cb-afdf1ac72761)

after:

![image](https://github.com/iExecBlockchainComputing/iexec-market-api/assets/26487010/7634e1ae-53f4-475e-8b6a-03abc0b8c0cd)
